### PR TITLE
Added SIMD optimizations for period = 8 or 16

### DIFF
--- a/src/common.hpp
+++ b/src/common.hpp
@@ -29,7 +29,7 @@
 #ifdef _WIN32_WINNT
     #include "mpreal.h"
 #else
-    #include <mpreal.h>
+    #include "mpreal.h"
 #endif
 
 

--- a/src/remdet.hpp
+++ b/src/remdet.hpp
@@ -16,5 +16,7 @@ template<typename T> void deldet(T *buffer, uint64_t size, T *detpart, uint64_t 
 // For T-specialized optimisations
 template<typename T> inline void detsum_func(T *buff, auto *detsum, uint64_t period);
 template<typename T> inline void detsub_func(T *buff, T *detpart, uint64_t period);
+// AVX2 specialization associated function
+void deldet_16_int16(int16_t *buffer, uint64_t size, int16_t *detpart);
 
 #endif // remdet_H


### PR DESCRIPTION
`deldet` is optimized via SIMD instructions for periods of length 8 and 16.
Function multi-versioning is used to provide fallback on CPU that don't support AVX2.

This is as fast as the parallel version, but uses a single core.
That points to a memory bottleneck.

Performace was tested on large array (size >> cpu_cache).

**Ideas for the future:**
- `getdet` could also  be optimized in the future.
- Support any period length by using many 256 bits register and 0-padding the last one
- AVX512 version maybe? Would need a cpu that supports it.